### PR TITLE
Feat: enable and disable admin merchants

### DIFF
--- a/app/controllers/admin_merchants_controller.rb
+++ b/app/controllers/admin_merchants_controller.rb
@@ -14,18 +14,23 @@ class AdminMerchantsController < ApplicationController
 
   def update
     merchant = Merchant.find(params[:merchant_id])
-    if merchant.update(merchant_params)
-      flash[:notice] = "Successfully Updated Information"
-      redirect_to "/admin/merchants/#{merchant.id}"
-    else
-      redirect_to "/admin/merchants/#{merchant.id}/edit"
-      flash[:alert] = "Error: #{error_message(merchant.errors)}"
+    if params.include?(:status)
+      merchant.update(merchant_params)
+      redirect_to '/admin/merchants'
+    elsif params.include?(:merchant_update)
+      if merchant.update(merchant_params)
+        flash[:notice] = "Successfully Updated Information"
+        redirect_to "/admin/merchants/#{merchant.id}"
+      else
+        redirect_to "/admin/merchants/#{merchant.id}/edit"
+        flash[:alert] = "Error: #{error_message(merchant.errors)}"
+      end
     end
   end
 
   private
 
     def merchant_params
-      params.permit(:name, :updated_at)
+      params.permit(:name, :updated_at, :status)
     end
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -10,5 +10,5 @@ class Transaction < ApplicationRecord
     # end
     #
     # vip.order()
-  end
+  # end
 end

--- a/app/views/admin_merchants/edit.html.erb
+++ b/app/views/admin_merchants/edit.html.erb
@@ -1,7 +1,8 @@
 <h1>Update Merchant Information</h1>
 
 <%= form_with url:"/admin/merchants/#{@merchant.id}", method: :patch, local: true do |form| %>
+<%= form.hidden_field :merchant_update %>
 <%= form.label :name %>
-<%= form.text_field :name %>
+<%= form.text_field :name, value:@merchant.name %>
 <%= form.submit "Submit Changes" %>
 <% end %>

--- a/app/views/admin_merchants/index.html.erb
+++ b/app/views/admin_merchants/index.html.erb
@@ -2,4 +2,11 @@
 
 <% @merchants.each do |merchant| %>
   <p><%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}" %></p>
+  <!-- <div class="#{merchant.id}-button"> -->
+  <% if merchant.status == false %>
+    <p><%= button_to "Enable", "/admin/merchants/#{merchant.id}", method: :patch, params: {status: true} %>
+  <% elsif merchant.status == true %>
+    <p><%= button_to "Disable", "/admin/merchants/#{merchant.id}", method: :patch, params: {status: false} %>
+  <% end %>
+  <!-- </div> -->
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,8 @@ Rails.application.routes.draw do
 
   get '/admin/merchants', to: 'admin_merchants#index'
   patch '/admin/merchants/:merchant_id', to: 'admin_merchants#update'
-  get '/admin/merchants/:merchant_id', to: 'admin_merchants#show'
   get '/admin/merchants/:merchant_id/edit', to: 'admin_merchants#edit'
+  get '/admin/merchants/:merchant_id', to: 'admin_merchants#show'
 
 
   resources :merchants, only: :index do

--- a/db/migrate/20211105203319_add_status_column_to_merchants.rb
+++ b/db/migrate/20211105203319_add_status_column_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddStatusColumnToMerchants < ActiveRecord::Migration[5.2]
+  def change
+    add_column :merchants, :status, :boolean, :default => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_02_195300) do
+ActiveRecord::Schema.define(version: 2021_11_05_203319) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2021_11_02_195300) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "status", default: true
   end
 
   create_table "transactions", force: :cascade do |t|

--- a/spec/features/admins/merchants/index_spec.rb
+++ b/spec/features/admins/merchants/index_spec.rb
@@ -20,4 +20,18 @@ RSpec.describe 'Admin Merchant Index' do
     expect(page).to have_content(@merchant_1.name)
     expect(page).to have_link(@merchant_1.name)
   end
+
+  it 'has a button to enable/disable a given merchant' do
+    visit '/admin/merchants'
+
+    expect(page).to have_button("Disable")
+    expect(@merchant_1.status).to eq(true)
+
+    within(".#{@merchant_1.id}-button") do
+      click_button "Disable"
+    end
+    
+    expect(page).to have_button("Enable")
+    expect(@merchant_1.status).to eq(false)
+  end
 end


### PR DESCRIPTION
User Story #14 

Merchants can be disabled and enabled with a button click. I added a new column to merchants called status and gave it a default value of true. I figured since there was 2 states it made sense to make it boolean. Enabled is true, disabled is false.

I also added a hidden_field to the edit merchant form to help my controllers conditional logic.

You'll need to drop, create, migrate and csv_load after pulling down to adjust for the new column data.