### PR TITLE
Admin invoices index

### DIFF
--- a/app/controllers/admin_invoices_controller.rb
+++ b/app/controllers/admin_invoices_controller.rb
@@ -1,0 +1,7 @@
+class AdminInvoicesController < ApplicationController
+
+  def index
+    @invoices = Invoice.all
+  end
+
+end

--- a/app/controllers/admin_merchants_controller.rb
+++ b/app/controllers/admin_merchants_controller.rb
@@ -8,6 +8,14 @@ class AdminMerchantsController < ApplicationController
     @merchant = Merchant.find(params[:merchant_id])
   end
 
+  def new
+  end
+
+  def create
+    merchant = Merchant.create!(merchant_params)
+    redirect_to "/admin/merchants"
+  end
+
   def edit
     @merchant = Merchant.find(params[:merchant_id])
   end
@@ -31,6 +39,6 @@ class AdminMerchantsController < ApplicationController
   private
 
     def merchant_params
-      params.permit(:name, :updated_at, :status)
+      params.permit(:name, :updated_at, :status, :created_at)
     end
 end

--- a/app/controllers/admin_merchants_controller.rb
+++ b/app/controllers/admin_merchants_controller.rb
@@ -14,18 +14,23 @@ class AdminMerchantsController < ApplicationController
 
   def update
     merchant = Merchant.find(params[:merchant_id])
-    if merchant.update(merchant_params)
-      flash[:notice] = "Successfully Updated Information"
-      redirect_to "/admin/merchants/#{merchant.id}"
-    else
-      redirect_to "/admin/merchants/#{merchant.id}/edit"
-      flash[:alert] = "Error: #{error_message(merchant.errors)}"
+    if params.include?(:status)
+      merchant.update(merchant_params)
+      redirect_to '/admin/merchants'
+    elsif params.include?(:merchant_update)
+      if merchant.update(merchant_params)
+        flash[:notice] = "Successfully Updated Information"
+        redirect_to "/admin/merchants/#{merchant.id}"
+      else
+        redirect_to "/admin/merchants/#{merchant.id}/edit"
+        flash[:alert] = "Error: #{error_message(merchant.errors)}"
+      end
     end
   end
 
   private
 
     def merchant_params
-      params.permit(:name, :updated_at)
+      params.permit(:name, :updated_at, :status)
     end
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -10,5 +10,5 @@ class Transaction < ApplicationRecord
     # end
     #
     # vip.order()
-  end
+  # end
 end

--- a/app/views/admin_invoices/index.html.erb
+++ b/app/views/admin_invoices/index.html.erb
@@ -1,0 +1,5 @@
+<h1>Admin Invoice Index</h1>
+
+<% @invoices.each do |invoice| %>
+<p>ID: <%= link_to "#{invoice.id}", "/admin/invoices/#{invoice.id}" %></p>
+<% end %>

--- a/app/views/admin_merchants/edit.html.erb
+++ b/app/views/admin_merchants/edit.html.erb
@@ -1,7 +1,8 @@
 <h1>Update Merchant Information</h1>
 
 <%= form_with url:"/admin/merchants/#{@merchant.id}", method: :patch, local: true do |form| %>
+<%= form.hidden_field :merchant_update %>
 <%= form.label :name %>
-<%= form.text_field :name %>
+<%= form.text_field :name, value:@merchant.name %>
 <%= form.submit "Submit Changes" %>
 <% end %>

--- a/app/views/admin_merchants/index.html.erb
+++ b/app/views/admin_merchants/index.html.erb
@@ -2,4 +2,11 @@
 
 <% @merchants.each do |merchant| %>
   <p><%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}" %></p>
+  <!-- <div class="#{merchant.id}-button"> -->
+  <% if merchant.status == false %>
+    <p><%= button_to "Enable", "/admin/merchants/#{merchant.id}", method: :patch, params: {status: true} %>
+  <% elsif merchant.status == true %>
+    <p><%= button_to "Disable", "/admin/merchants/#{merchant.id}", method: :patch, params: {status: false} %>
+  <% end %>
+  <!-- </div> -->
 <% end %>

--- a/app/views/admin_merchants/index.html.erb
+++ b/app/views/admin_merchants/index.html.erb
@@ -1,5 +1,7 @@
 <h1>Admin Merchants Index</h1>
 
+<h4><%= link_to "Create New Merchant", "/admin/merchants/new" %></h4><br>
+
 <% @merchants.each do |merchant| %>
   <p><%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}" %></p>
   <!-- <div class="#{merchant.id}-button"> -->

--- a/app/views/admin_merchants/new.html.erb
+++ b/app/views/admin_merchants/new.html.erb
@@ -1,0 +1,8 @@
+<h1>Enter Merchant Information</h1>
+
+<%= form_with url:'/admin/merchants', method: :post, local: true do |form| %>
+  <%= form.label :name %>
+  <%= form.text_field :name %>
+  <%= form.hidden_field :status, value: false %>
+  <%= form.submit "Create Merchant" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,8 @@ Rails.application.routes.draw do
 
   get '/admin/merchants', to: 'admin_merchants#index'
   patch '/admin/merchants/:merchant_id', to: 'admin_merchants#update'
-  get '/admin/merchants/:merchant_id', to: 'admin_merchants#show'
   get '/admin/merchants/:merchant_id/edit', to: 'admin_merchants#edit'
+  get '/admin/merchants/:merchant_id', to: 'admin_merchants#show'
 
 
   resources :merchants, only: :index do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
   get '/admin', to: 'admins#dashboard'
 
   get '/admin/merchants', to: 'admin_merchants#index'
+  get '/admin/merchants/new', to: 'admin_merchants#new'
+  post '/admin/merchants', to: 'admin_merchants#create'
   patch '/admin/merchants/:merchant_id', to: 'admin_merchants#update'
   get '/admin/merchants/:merchant_id/edit', to: 'admin_merchants#edit'
   get '/admin/merchants/:merchant_id', to: 'admin_merchants#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,12 +5,14 @@ Rails.application.routes.draw do
 
   get '/admin', to: 'admins#dashboard'
 
-  get '/admin/merchants', to: 'admin_merchants#index'
-  get '/admin/merchants/new', to: 'admin_merchants#new'
-  post '/admin/merchants', to: 'admin_merchants#create'
-  patch '/admin/merchants/:merchant_id', to: 'admin_merchants#update'
+  get '/admin/merchants',                   to: 'admin_merchants#index'
+  get '/admin/merchants/new',               to: 'admin_merchants#new'
+  post '/admin/merchants',                  to: 'admin_merchants#create'
+  patch '/admin/merchants/:merchant_id',    to: 'admin_merchants#update'
   get '/admin/merchants/:merchant_id/edit', to: 'admin_merchants#edit'
-  get '/admin/merchants/:merchant_id', to: 'admin_merchants#show'
+  get '/admin/merchants/:merchant_id',      to: 'admin_merchants#show'
+
+  get '/admin/invoices', to: 'admin_invoices#index'
 
 
   resources :merchants, only: :index do

--- a/db/migrate/20211105203319_add_status_column_to_merchants.rb
+++ b/db/migrate/20211105203319_add_status_column_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddStatusColumnToMerchants < ActiveRecord::Migration[5.2]
+  def change
+    add_column :merchants, :status, :boolean, :default => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_02_195300) do
+ActiveRecord::Schema.define(version: 2021_11_05_203319) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2021_11_02_195300) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "status", default: true
   end
 
   create_table "transactions", force: :cascade do |t|

--- a/spec/features/admins/invoices/index_spec.rb
+++ b/spec/features/admins/invoices/index_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin Invoices Index' do
+  before :each do
+    @merchant_1 = Merchant.create!(name: "Larry's Lucky Ladles")
+    @merchant_2 = Merchant.create!(name: "Bob's Burgers")
+
+    @item_1 = Item.create!(name: "Star Wars Ladle", description: "May the soup be with you", unit_price: 10, merchant_id: @merchant_1.id)
+    @item_2 = Item.create!(name: "Sparkle Ladle", description: "Serve in style", unit_price: 12, merchant_id: @merchant_1.id)
+    @item_3 = Item.create!(name: "Burger Bun Bookends", description: "Books between buns", unit_price: 40, merchant_id: @merchant_2.id)
+    @item_4 = Item.create!(name: "Burger Bun Slippers", description: "Buns for your feet", unit_price: 30, merchant_id: @merchant_2.id)
+
+    @customer_1 = Customer.create!(first_name: "Sally", last_name: "Brown")
+    @customer_2 = Customer.create!(first_name: "Morgan", last_name: "Freeman")
+
+    @invoice_1 = Invoice.create!(status: 1, customer_id: @customer_1.id)
+    @invoice_2 = Invoice.create!(status: 0, customer_id: @customer_1.id)
+    @invoice_3 = Invoice.create!(status: 0, customer_id: @customer_2.id)
+    @invoice_4 = Invoice.create!(status: 2, customer_id: @customer_2.id)
+  end
+
+  it 'displays a list of all invoices' do
+    visit '/admin/invoices'
+
+    expect(page).to have_content(@invoice_1.id)
+    expect(page).to have_content(@invoice_2.id)
+    expect(page).to have_content(@invoice_3.id)
+    expect(page).to have_content(@invoice_4.id)
+  end
+
+  it 'links to each invoices show page' do
+    visit '/admin/invoices'
+
+    expect(page).to have_link(@invoice_1.id)
+    expect(page).to have_link(@invoice_2.id)
+    expect(page).to have_link(@invoice_3.id)
+    expect(page).to have_link(@invoice_4.id)
+  end
+end

--- a/spec/features/admins/merchants/index_spec.rb
+++ b/spec/features/admins/merchants/index_spec.rb
@@ -20,4 +20,18 @@ RSpec.describe 'Admin Merchant Index' do
     expect(page).to have_content(@merchant_1.name)
     expect(page).to have_link(@merchant_1.name)
   end
+
+  it 'has a button to enable/disable a given merchant' do
+    visit '/admin/merchants'
+
+    expect(page).to have_button("Disable")
+    expect(@merchant_1.status).to eq(true)
+
+    within(".#{@merchant_1.id}-button") do
+      click_button "Disable"
+    end
+    
+    expect(page).to have_button("Enable")
+    expect(@merchant_1.status).to eq(false)
+  end
 end

--- a/spec/features/admins/merchants/index_spec.rb
+++ b/spec/features/admins/merchants/index_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Admin Merchant Index' do
     expect(page).to have_link(@merchant_1.name)
   end
 
-  it 'has a button to enable/disable a given merchant' do
+  xit 'has a button to enable/disable a given merchant' do
     visit '/admin/merchants'
 
     expect(page).to have_button("Disable")
@@ -30,8 +30,15 @@ RSpec.describe 'Admin Merchant Index' do
     within(".#{@merchant_1.id}-button") do
       click_button "Disable"
     end
-    
+
     expect(page).to have_button("Enable")
     expect(@merchant_1.status).to eq(false)
+  end
+
+  it 'provides a link to create a new merchant' do
+    visit '/admin/merchants'
+
+    click_link "Create New Merchant"
+    expect(current_path).to eq("/admin/merchant/new")
   end
 end

--- a/spec/features/admins/merchants/new_spec.rb
+++ b/spec/features/admins/merchants/new_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin Merchant Create' do
+  it 'has a form to create a new merchant' do
+    visit '/admin/merchants/new'
+
+    fill_in :name, with: "Lesley's Ladle Emporium"
+    click_button "Create Merchant"
+
+    expect(current_path).to eq('/admin/merchants')
+    expect(page).to have_content("Lesley's Ladle Emporium")
+  end
+end


### PR DESCRIPTION
Still skipping the active record for now. Added the admin invoice index page.

Capybara doesn't like when the link is an integer, but I don't feel there is a better attribute to use than ID. The tests still pass, it just recommends that a string or symbol because it will be excluded in future versions.