### PR TITLE
Add: admin merchant index lists by status

### DIFF
--- a/app/controllers/admin_merchants_controller.rb
+++ b/app/controllers/admin_merchants_controller.rb
@@ -1,7 +1,8 @@
 class AdminMerchantsController < ApplicationController
 
   def index
-    @merchants = Merchant.all
+    @enabled_merchants = Merchant.enabled?
+    @disabled_merchants = Merchant.disabled?
   end
 
   def show

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -2,4 +2,12 @@ class Merchant < ApplicationRecord
   has_many :items
   has_many :invoice_items, through: :items
   has_many :invoices, through: :invoice_items
+
+  def self.enabled?
+    where(status: true)
+  end
+
+  def self.disabled?
+    where(status: false)
+  end
 end

--- a/app/views/admin_merchants/index.html.erb
+++ b/app/views/admin_merchants/index.html.erb
@@ -2,7 +2,20 @@
 
 <h4><%= link_to "Create New Merchant", "/admin/merchants/new" %></h4><br>
 
-<% @merchants.each do |merchant| %>
+<h3>Enabled Merchants</h3>
+<% @enabled_merchants.each do |merchant| %>
+  <p><%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}" %></p>
+  <!-- <div class="#{merchant.id}-button"> -->
+  <% if merchant.status == false %>
+    <p><%= button_to "Enable", "/admin/merchants/#{merchant.id}", method: :patch, params: {status: true} %>
+  <% elsif merchant.status == true %>
+    <p><%= button_to "Disable", "/admin/merchants/#{merchant.id}", method: :patch, params: {status: false} %>
+  <% end %>
+  <!-- </div> -->
+<% end %>
+
+<h3>Disabled Merchants</h3>
+<% @disabled_merchants.each do |merchant| %>
   <p><%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}" %></p>
   <!-- <div class="#{merchant.id}-button"> -->
   <% if merchant.status == false %>

--- a/spec/features/admins/merchants/index_spec.rb
+++ b/spec/features/admins/merchants/index_spec.rb
@@ -39,6 +39,15 @@ RSpec.describe 'Admin Merchant Index' do
     visit '/admin/merchants'
 
     click_link "Create New Merchant"
-    expect(current_path).to eq("/admin/merchant/new")
+    expect(current_path).to eq("/admin/merchants/new")
+  end
+
+  it 'seperates merchants by status' do
+    visit '/admin/merchants'
+
+    expect(page).to have_content("Enabled Merchants")
+    expect(page).to have_content("Disabled Merchants")
+
+    expect(@merchant_1.name).to appear_before("Disabled Merchants")
   end
 end


### PR DESCRIPTION
groups merchants by status. I used 2 different class methods to pull them into enabled_merchants and disabled_merchants. I also tested it on local to make sure when merchants are enabled/disabled they move to the correct category as well.